### PR TITLE
Fix NPE. Access preference via ReactApplicationContext

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNDefaultPreferenceModule.java
+++ b/android/src/main/java/com/reactlibrary/RNDefaultPreferenceModule.java
@@ -101,7 +101,7 @@ public class RNDefaultPreferenceModule extends ReactContextBaseJavaModule {
   }
 
   private SharedPreferences getPreferences() {
-    return getCurrentActivity().getSharedPreferences("react-native", Context.MODE_PRIVATE);
+    return getReactApplicationContext().getSharedPreferences("react-native", Context.MODE_PRIVATE);
   }
   private SharedPreferences.Editor getEditor() {
     return getPreferences().edit();


### PR DESCRIPTION
 Fix NPE. Access preference via ReactApplicationContext instead of CurrentActivity on Android