### PR TITLE
Add missing homepage attribute in podspec

### DIFF
--- a/RNDefaultPreference.podspec
+++ b/RNDefaultPreference.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.description    = package['description']
   s.license        = package['license']
   s.author         = package['author']
+  s.homepage       = package['homepage']
   s.source         = { :git => 'https://github.com/kevinresol/react-native-default-preference.git' }
 
   s.requires_arc   = true

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   "license": "MIT",
   "peerDependencies": {
     "react-native": "^0.29.0"
-
-  }
+  },
+  "homepage": "https://github.com/kevinresol/react-native-default-preference#readme"
 }


### PR DESCRIPTION
@kevinresol Sorry about the incorrect Podspec file in the last PR. Apparently the homepage attribute is compulsory and I missed that last time. I've tested the lib locally this time and it works :) Sorry!