### PR TITLE
Fallback from Cordova Native Storage Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,18 @@ function setMultiple(data:Object):Promise<Void>;
 function clearMultiple(keys:Array<String>):Promise<Void>;
 function getAll():Promise<Object>;
 function clearAll():Promise<Void>;
+function setPreferencesName(name:String):Void; \\ ANDROID ONLY
 ```
-  
+
+## Cordova Native Storage Compatibility
+This module is compatible with cordova-plugin-native-storage.
+
+### Android
+You need to use the same SharedPreference as in the cordova plugin, to do so add
+the following line:
+
+```js
+import { Platform } from 'react-native';
+// ...
+if (Platform.OS === 'android') DefaultPreference.setPreferencesName('NativeStorage');
+```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ function setMultiple(data:Object):Promise<Void>;
 function clearMultiple(keys:Array<String>):Promise<Void>;
 function getAll():Promise<Object>;
 function clearAll():Promise<Void>;
-function setPreferencesName(name:String):Void; \\ ANDROID ONLY
+function setName(name:String):Promise<Void>; \\ ANDROID ONLY
+function getName():Promise<String>; \\ ANDROID ONLY
 ```
 
 ## Cordova Native Storage Compatibility

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ function setMultiple(data:Object):Promise<Void>;
 function clearMultiple(keys:Array<String>):Promise<Void>;
 function getAll():Promise<Object>;
 function clearAll():Promise<Void>;
-function setName(name:String):Promise<Void>; \\ ANDROID ONLY
-function getName():Promise<String>; \\ ANDROID ONLY
+function setName(name:String):Promise<Void>;
+function getName():Promise<String>;
 ```
 
 ## Cordova Native Storage Compatibility
@@ -72,3 +72,7 @@ import { Platform } from 'react-native';
 // ...
 if (Platform.OS === 'android') DefaultPreference.setPreferencesName('NativeStorage');
 ```
+
+### iOS
+You don't need to change the name, as cordova-plugin-native-storage uses the default
+value.

--- a/android/src/main/java/com/reactlibrary/RNDefaultPreferenceModule.java
+++ b/android/src/main/java/com/reactlibrary/RNDefaultPreferenceModule.java
@@ -101,7 +101,7 @@ public class RNDefaultPreferenceModule extends ReactContextBaseJavaModule {
   }
 
   private SharedPreferences getPreferences() {
-    return getReactApplicationContext().getSharedPreferences("react-native", Context.MODE_PRIVATE);
+    return getReactApplicationContext().getSharedPreferences("NativeStorage", Context.MODE_PRIVATE);
   }
   private SharedPreferences.Editor getEditor() {
     return getPreferences().edit();

--- a/android/src/main/java/com/reactlibrary/RNDefaultPreferenceModule.java
+++ b/android/src/main/java/com/reactlibrary/RNDefaultPreferenceModule.java
@@ -102,8 +102,14 @@ public class RNDefaultPreferenceModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void setPreferencesName(String preferencesName) {
+  public void setName(String preferencesName, Promise promise) {
     this.preferencesName = preferencesName;
+    promise.resolve(null);
+  }
+
+  @ReactMethod
+  public void getName(Promise promise) {
+    promise.resolve(preferencesName);
   }
 
   private SharedPreferences getPreferences() {

--- a/android/src/main/java/com/reactlibrary/RNDefaultPreferenceModule.java
+++ b/android/src/main/java/com/reactlibrary/RNDefaultPreferenceModule.java
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.WritableMap;
 import java.util.Map;
 
 public class RNDefaultPreferenceModule extends ReactContextBaseJavaModule {
+  private String preferencesName = "react-native";
 
   private final ReactApplicationContext reactContext;
 
@@ -100,8 +101,13 @@ public class RNDefaultPreferenceModule extends ReactContextBaseJavaModule {
     promise.resolve(null);
   }
 
+  @ReactMethod
+  public void setPreferencesName(String preferencesName) {
+    this.preferencesName = preferencesName;
+  }
+
   private SharedPreferences getPreferences() {
-    return getReactApplicationContext().getSharedPreferences("NativeStorage", Context.MODE_PRIVATE);
+    return getReactApplicationContext().getSharedPreferences(preferencesName, Context.MODE_PRIVATE);
   }
   private SharedPreferences.Editor getEditor() {
     return getPreferences().edit();

--- a/ios/RNDefaultPreference.h
+++ b/ios/RNDefaultPreference.h
@@ -1,5 +1,12 @@
 
-#import "RCTBridgeModule.h"
+// import RCTBridgeModule
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#elif __has_include(“RCTBridgeModule.h”)
+#import “RCTBridgeModule.h”
+#else
+#import “React/RCTBridgeModule.h” // Required when used as a Pod in a Swift project
+#endif
 
 @interface RNDefaultPreference : NSObject <RCTBridgeModule>
 

--- a/ios/RNDefaultPreference.m
+++ b/ios/RNDefaultPreference.m
@@ -3,85 +3,111 @@
 
 @implementation RNDefaultPreference
 
+NSString* defaultSuiteName = nil;
+
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_get_main_queue();
 }
+
+- (NSUserDefaults *) getDefaultUser{
+    if(defaultSuiteName == nil){
+        NSLog(@"No prefer suite for userDefaults. Using standard one.");
+        return [NSUserDefaults standardUserDefaults];
+    } else {
+        NSLog(@"Using %@ suite for userDefaults", defaultSuiteName);
+        return [[NSUserDefaults alloc] initWithSuiteName:defaultSuiteName];
+    }
+}
+
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(get:(NSString *)key
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(setName:(NSString *)name
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
 {
-    resolve([[NSUserDefaults standardUserDefaults] stringForKey:key]);
+    defaultSuiteName = name;
+    resolve([NSNull null]);
+}
+
+RCT_EXPORT_METHOD(getName:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
+{
+    resolve(defaultSuiteName);
+}
+
+RCT_EXPORT_METHOD(get:(NSString *)key
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    resolve([[self getDefaultUser] stringForKey:key]);
 }
 
 RCT_EXPORT_METHOD(set:(NSString *)key value:(NSString *)value
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 {
-    [[NSUserDefaults standardUserDefaults] setObject:value forKey:key];
+    [[self getDefaultUser] setObject:value forKey:key];
     resolve([NSNull null]);
 }
 
 RCT_EXPORT_METHOD(clear:(NSString *)key
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
 {
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+    [[self getDefaultUser] removeObjectForKey:key];
     resolve([NSNull null]);
 }
 
 RCT_EXPORT_METHOD(getMultiple:(NSArray *)keys
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
 {
     NSMutableArray *result = [NSMutableArray array];
     for(NSString *key in keys) {
-        NSString *value = [[NSUserDefaults standardUserDefaults] stringForKey:key];
+        NSString *value = [[self getDefaultUser] stringForKey:key];
         [result addObject: value == nil ? [NSNull null] : value];
     }
     resolve(result);
 }
 
 RCT_EXPORT_METHOD(setMultiple:(NSDictionary *)data
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
 {
     for (id key in data) {
-        [[NSUserDefaults standardUserDefaults] setObject:[data objectForKey:key] forKey:key];
+        [[self getDefaultUser] setObject:[data objectForKey:key] forKey:key];
     }
     resolve([NSNull null]);
 }
 
 RCT_EXPORT_METHOD(clearMultiple:(NSArray *)keys
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
 {
     for(NSString *key in keys) {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+        [[self getDefaultUser] removeObjectForKey:key];
     }
     resolve([NSNull null]);
 }
 
 RCT_EXPORT_METHOD(getAll:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                  reject:(__unused RCTPromiseRejectBlock)reject)
 {
-    NSArray *keys = [[[NSUserDefaults standardUserDefaults] dictionaryRepresentation] allKeys];
+    NSArray *keys = [[[self getDefaultUser] dictionaryRepresentation] allKeys];
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     for(NSString *key in keys) {
-        NSString *value = [[NSUserDefaults standardUserDefaults] stringForKey:key];
+        NSString *value = [[self getDefaultUser] stringForKey:key];
         result[key] = value == nil ? [NSNull null] : value;
     }
     resolve(result);
 }
 
-RCT_EXPORT_METHOD(clearAll:resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(clearAll:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 {
-    NSArray *keys = [[[NSUserDefaults standardUserDefaults] dictionaryRepresentation] allKeys];
-    [self clearMultiple:keys resolver:resolve rejecter:reject];
+    NSArray *keys = [[[self getDefaultUser] dictionaryRepresentation] allKeys];
+    [self clearMultiple:keys resolve:resolve reject:reject];
 }
 
 @end
-  

--- a/ios/RNDefaultPreference.m
+++ b/ios/RNDefaultPreference.m
@@ -38,14 +38,14 @@ RCT_EXPORT_METHOD(getName:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(get:(NSString *)key
                   resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  reject:(__unused RCTPromiseRejectBlock)reject)
 {
     resolve([[self getDefaultUser] stringForKey:key]);
 }
 
 RCT_EXPORT_METHOD(set:(NSString *)key value:(NSString *)value
                   resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  reject:(__unused RCTPromiseRejectBlock)reject)
 {
     [[self getDefaultUser] setObject:value forKey:key];
     resolve([NSNull null]);


### PR DESCRIPTION
I am upgrading my app from cordova to react-native, from each I was saving user data using cordova-plugin-native-storage, which uses SharedPreferences and UserDefaults, so I went into this module to do so.
The only thing not there already is the android preference name (different in that package), so I made a function to set it (and added instructions to the README)