### PR TITLE
Update build tools

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,8 +2,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "kevinresol",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.29.0"
+    "react-native": ">=0.29.0"
   },
   "homepage": "https://github.com/kevinresol/react-native-default-preference#readme"
 }


### PR DESCRIPTION
- Update Android build tools version
- Get rid of warning/error when using react-native 0.49.3
