### PR TITLE
Add support for tvOS

### DIFF
--- a/RNDefaultPreference.podspec
+++ b/RNDefaultPreference.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
 
-  s.platform     = :ios, "9.0"
+  s.platforms      = { :ios => "9.0", :tvos => "11.0" }
   s.ios.deployment_target = '9.0'
   
   s.preserve_paths = 'README.md', 'package.json', 'index.js'


### PR DESCRIPTION
This library is very useful for tvOS, since it doesn't support persistent storage, except for UserDefaults. 
I've checked and it works completely fine with my project. So, the only thing necessary is to add tvOS to platforms.