### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/RNDefaultPreference.podspec
+++ b/RNDefaultPreference.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'iOS/*.{h,m}'
   s.source         = { :git => 'https://github.com/kevinresol/react-native-default-preference.git' }
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Compilation fails on Xcode 12 with `Undefined symbols for architecture` errors, due to the React dependency in the podspec.

See the react-native issue here - https://github.com/facebook/react-native/issues/29633#issuecomment-694187116