### PR TITLE
Enable to read from boolean values

### DIFF
--- a/android/src/main/java/com/kevinresol/react_native_default_preference/RNDefaultPreferenceModule.java
+++ b/android/src/main/java/com/kevinresol/react_native_default_preference/RNDefaultPreferenceModule.java
@@ -35,7 +35,14 @@ public class RNDefaultPreferenceModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void get(String key, Promise promise) {
-    promise.resolve(getPreferences().getString(key, null));
+      try {
+          promise.resolve(getPreferences().getString(key, null));
+      } catch(ClassCastException e){
+          if(!getPreferences().contains(key)) {
+              promise.resolve(null);
+          }
+          promise.resolve(getPreferences().getBoolean(key, false) ? "true" : "false");
+      }
   }
 
   @ReactMethod


### PR DESCRIPTION
When trying to fetch a value set by another dependency, the error bellow is triggered:

![Screenshot 2021-01-20 at 18 26 32](https://user-images.githubusercontent.com/1174345/105525517-7c6f5480-5ce1-11eb-9bf5-68a6ec6a5b05.png)

This PR allows to, instead of having this error, retrieve a string value from the native-set preferences.