### PR TITLE
fix: use default shared preferences name on android

### DIFF
--- a/android/src/main/java/com/kevinresol/react_native_default_preference/RNDefaultPreferenceModule.java
+++ b/android/src/main/java/com/kevinresol/react_native_default_preference/RNDefaultPreferenceModule.java
@@ -19,13 +19,14 @@ import com.facebook.react.bridge.WritableMap;
 import java.util.Map;
 
 public class RNDefaultPreferenceModule extends ReactContextBaseJavaModule {
-  private String preferencesName = "react-native";
+  private String preferencesName;
 
   private final ReactApplicationContext reactContext;
 
   public RNDefaultPreferenceModule(ReactApplicationContext reactContext) {
     super(reactContext);
     this.reactContext = reactContext;
+    this.preferencesName = reactContext.getPackageName() + "_preferences";
   }
 
   @Override


### PR DESCRIPTION
On iOS the default behaviour is returning default `NSUserDefaults`, to keep iOS and Android working the same I set the android default preferences instead of 'react-native'

**Breaking change:**
Current user that are using 'react-native' preferencesName need to call `setName` to avoid loosing their data.