### PR TITLE
Update types as `get` will return undefined if a key is not set on ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ DefaultPreference.set('my key', 'my value').then(function() {console.log('done')
 
 ## API
 
-```haxe
-function get(key:String):Promise<String>;
-function set(key:String, value:String):Promise<Void>;
-function clear(key:String):Promise<Void>;
-function getMultiple(keys:Array<String>):Promise<Array<String>>;
-function setMultiple(data:Object):Promise<Void>;
-function clearMultiple(keys:Array<String>):Promise<Void>;
-function getAll():Promise<Object>;
-function clearAll():Promise<Void>;
+```typescript
+function get(key: string): Promise<string | undefined>;
+function set(key: string, value: string): Promise<void>;
+function clear(key: string): Promise<void>;
+function getMultiple(keys: string[]): Promise<string[]>;
+function setMultiple(data: {[key: string]: string}): Promise<void>;
+function clearMultiple(keys: string[]): Promise<void>;
+function getAll(): Promise<{[key: string]: string}>;
+function clearAll(): Promise<void>;
 
 /** Gets and sets the current preferences file name (android) or user default suite name (ios) **/
-function getName():Promise<String>;
-function setName(name:String):Promise<Void>;
+function getName(): Promise<string>;
+function setName(name: string): Promise<void>;
 ```
 
 ## Cordova Native Storage Compatibility

--- a/flow-typed/index.js
+++ b/flow-typed/index.js
@@ -9,7 +9,7 @@ declare module "react-native-default-preference" {
     [key: string]: string;
   }
   declare export default class RNDefaultPreference {
-    static get(key: string): Promise<string>;
+    static get(key: string): Promise<string | undefined>;
     static set(key: string, value: string): Promise<void>;
     static clear(key: string): Promise<void>;
     static getMultiple(keys: string[]): Promise<RNDefaultPreferenceKeys>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module 'react-native-default-preference' {
   }
 
   export default class RNDefaultPreference {
-    static get(key: string): Promise<string>;
+    static get(key: string): Promise<string | undefined>;
     static set(key: string, value: string): Promise<void>;
     static clear(key: string): Promise<void>;
     static getMultiple(keys: string[]): Promise<string[]>;


### PR DESCRIPTION
Just noticed this when playing around. I've also updated the types in the readme, but I don't know haxe so I've switched them to match the typescript types. I hope that's ok!