### PR TITLE
Update types as `get` will return null if a key is not set on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ DefaultPreference.set('my key', 'my value').then(function() {console.log('done')
 ## API
 
 ```typescript
-function get(key: string): Promise<string | undefined>;
+function get(key: string): Promise<string | undefined | null>;
 function set(key: string, value: string): Promise<void>;
 function clear(key: string): Promise<void>;
 function getMultiple(keys: string[]): Promise<string[]>;

--- a/flow-typed/index.js
+++ b/flow-typed/index.js
@@ -9,7 +9,7 @@ declare module "react-native-default-preference" {
     [key: string]: string;
   }
   declare export default class RNDefaultPreference {
-    static get(key: string): Promise<string | undefined>;
+    static get(key: string): Promise<string | undefined | null>;
     static set(key: string, value: string): Promise<void>;
     static clear(key: string): Promise<void>;
     static getMultiple(keys: string[]): Promise<RNDefaultPreferenceKeys>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module 'react-native-default-preference' {
   }
 
   export default class RNDefaultPreference {
-    static get(key: string): Promise<string | undefined>;
+    static get(key: string): Promise<string | undefined | null>;
     static set(key: string, value: string): Promise<void>;
     static clear(key: string): Promise<void>;
     static getMultiple(keys: string[]): Promise<string[]>;


### PR DESCRIPTION
Similar to #63 except I was playing around on Android this time. I've only updated the types as I didn't want to break any existing behaviour by getting iOS and Android to return the same "empty" value.