### PR TITLE
New getObject method compatible with Titanium Ti.App.Properties

### DIFF
--- a/android/src/main/java/com/kevinresol/react_native_default_preference/RNDefaultPreferenceModule.java
+++ b/android/src/main/java/com/kevinresol/react_native_default_preference/RNDefaultPreferenceModule.java
@@ -38,6 +38,12 @@ public class RNDefaultPreferenceModule extends ReactContextBaseJavaModule {
   public void get(String key, Promise promise) {
     promise.resolve(getPreferences().getString(key, null));
   }
+ 
+  @ReactMethod
+  public void getObject(String key, Promise promise) {
+
+    promise.resolve(new JSONObject(getPreferences().getString(key, null)));
+  }
 
   @ReactMethod
   public void set(String key, String value, Promise promise) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ declare module 'react-native-default-preference' {
 
   export default class RNDefaultPreference {
     static get(key: string): Promise<string | undefined | null>;
+    static getObject(key: string): Promise<object | undefined | null>;
     static set(key: string, value: string): Promise<void>;
     static clear(key: string): Promise<void>;
     static getMultiple(keys: string[]): Promise<string[]>;

--- a/ios/RNDefaultPreference.m
+++ b/ios/RNDefaultPreference.m
@@ -43,6 +43,18 @@ RCT_EXPORT_METHOD(get:(NSString *)key
     resolve([[self getDefaultUser] stringForKey:key]);
 }
 
+RCT_EXPORT_METHOD(getObject:(NSString *)key
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
+{
+    id theObject = [[self getDefaultUser] objectForKey:key];
+    if ([theObject isKindOfClass:[NSData class]]) {
+        resolve([NSKeyedUnarchiver unarchiveObjectWithData:theObject]);
+    } else {
+        resolve(theObject);
+    }
+}
+
 RCT_EXPORT_METHOD(set:(NSString *)key value:(NSString *)value
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
This module already works perfectly with Android migrations from Appcelerator Titanium by using `DefaultPreference.setName('titanium')`. On the iOS side, these values are often stored as NSData and need to be decoded.  This new getObject method accomplishes that.  Referenced from https://github.com/tidev/titanium_mobile/blob/master/iphone/Classes/TiAppPropertiesProxy.m.