### PR TITLE
Removing NSLog statements to reduce Xcode log clutter

### DIFF
--- a/ios/RNDefaultPreference.m
+++ b/ios/RNDefaultPreference.m
@@ -12,10 +12,8 @@ NSString* defaultSuiteName = nil;
 
 - (NSUserDefaults *) getDefaultUser{
     if(defaultSuiteName == nil){
-        NSLog(@"No prefer suite for userDefaults. Using standard one.");
         return [NSUserDefaults standardUserDefaults];
     } else {
-        NSLog(@"Using %@ suite for userDefaults", defaultSuiteName);
         return [[NSUserDefaults alloc] initWithSuiteName:defaultSuiteName];
     }
 }


### PR DESCRIPTION
While running an app using `react-native-default-preference,` many NSLog messages are logged to the console. These log messages are nice but can be overwhelming for an app even moderately uses this package. If it is okay with you, can we remove these messages?

Thank you so much for this opening source project. ❤️ 


```log
2024-03-28 08:26:57.987111-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987152-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987187-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987241-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987287-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987324-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987358-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987392-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987425-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987547-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987578-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987614-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987645-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
2024-03-28 08:26:57.987676-0400 TestApp[21600:5888864] No prefer suite for userDefaults. Using standard one.
```